### PR TITLE
Improve PGS parsing

### DIFF
--- a/subtle/core/media.py
+++ b/subtle/core/media.py
@@ -222,6 +222,7 @@ class MediaTrack:
         """Read the content of the track file."""
         if self._path and self._wrapper:
             self._wrapper.read(self._path)
+            self._wrapper.checkFrames()
         return
 
     def getFrame(self, index: int) -> FrameBase | None:

--- a/subtle/formats/pgssubs.py
+++ b/subtle/formats/pgssubs.py
@@ -230,7 +230,7 @@ class DisplaySet:
         return
 
     def isValid(self) -> bool:
-        return self._pcs is not None and self._pcs.valid  # and len(self._wds) > 0
+        return self._pcs is not None and self._pcs.valid
 
     def isClearFrame(self) -> bool:
         return self._pcs.compState == COMP_NORMAL and self._pcs.compObjectCount == 0

--- a/subtle/formats/pgssubs.py
+++ b/subtle/formats/pgssubs.py
@@ -291,8 +291,7 @@ class DisplaySet:
                         raw += palette[data[p+3]] * ((b2 & 0x3f)*256 + data[p+2])
                         p += 4
 
-                rect = QRect(offset, box)
-                frame = frame.united(rect)
+                frame = frame.united(QRect(offset, box))
                 painter.drawImage(offset, QImage(
                     raw, box.width(), box.height(), QImage.Format.Format_ARGB32
                 ))


### PR DESCRIPTION
This PR drops the requirements for PGS files that a Window Segment must contain a window definition, which is sometimes not the case. The window information is thus no longer used for the object offset when rendering the PGS image. Instead the offset defined in the Presentation Segment is used instead. This one seems to always be set.

This PR also adds a check that the end timestamp for a frame is set. If it is not, the start time of the next fram, minus 90 ms, is used.