### PR TITLE
Allow cancelling tracks extraction

### DIFF
--- a/subtle/core/mkvextract.py
+++ b/subtle/core/mkvextract.py
@@ -55,6 +55,13 @@ class MkvExtract(QObject):
             logger.debug("Starting process %d", self._pid)
         return
 
+    def cancel(self) -> None:
+        """Cancel the process."""
+        if isinstance(self._process, QProcess):
+            logger.debug("Killing process %d", self._pid)
+            self._process.kill()
+        return
+
     ##
     #  Private Slots
     ##


### PR DESCRIPTION
This PR adds a "Cancel" button to the media file box, after the "Extract All", to cancel the extraction process.