### PR TITLE
Allow adding an offset to SRT file writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,13 @@
 .venv/
 .ruff_cache/
 *.pyc
+uv.lock
 
 # Tests
 .pytest_cache
 .coverage
 coverage.*
 htmlcov/
+
+# Package
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "subtle"
-authors = [
-    {name = "Veronica Berglyd Olsen", email = "code@vkbo.net"},
-]
+authors = [{ name = "Veronica Berglyd Olsen", email = "code@vkbo.net" }]
 description = "A simple subtitle editor and converter"
-readme = {file = "README.md", content-type = "text/markdown"}
-license = {text = "GNU General Public License v3"}
+readme = { file = "README.md", content-type = "text/markdown" }
+license = { text = "GNU General Public License v3" }
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
@@ -23,10 +21,7 @@ classifiers = [
     "Topic :: Multimedia",
 ]
 requires-python = ">=3.11"
-dependencies = [
-    "pyqt6>=6.4",
-    "pyenchant>=3.0.0",
-]
+dependencies = ["pyqt6>=6.4", "pyenchant>=3.0.0"]
 dynamic = ["version"]
 
 [project.urls]
@@ -38,13 +33,13 @@ Issues = "https://github.com/vkbo/subtle/issues"
 subtle = "subtle:main"
 
 [tool.setuptools.dynamic]
-version = {attr = "subtle.__version__"}
+version = { attr = "subtle.__init__.__version__" }
 
 [tool.setuptools.packages.find]
 include = ["subtle*"]
 
 [tool.isort]
-py_version="311"
+py_version = "311"
 line_length = 99
 wrap_length = 79
 multi_line_output = 5
@@ -56,7 +51,7 @@ forced_separate = ["tests.*", "PyQt6.*"]
 line-length = 99
 
 [tool.ruff.lint]
-preview = true
+preview = false
 
 # Rules: https://docs.astral.sh/ruff/rules
 select = [

--- a/subtle/gui/subsview.py
+++ b/subtle/gui/subsview.py
@@ -124,13 +124,13 @@ class GuiSubtitleView(QWidget):
             self._updateItemText(item, frame.text)
         return
 
-    @pyqtSlot(Path)
-    def writeSrtFile(self, path: Path) -> None:
+    @pyqtSlot(Path, float)
+    def writeSrtFile(self, path: Path, offset: float = 0.0) -> None:
         """Save the processed subtitles to an SRT file."""
         if SHARED.media.currentTrack:
             writer = SRTSubs()
             SHARED.media.currentTrack.copyFrames(writer)
-            writer.write(path)
+            writer.write(path, offset)
         return
 
     @pyqtSlot(Path)

--- a/subtle/gui/toolspanel.py
+++ b/subtle/gui/toolspanel.py
@@ -29,8 +29,8 @@ from subtle.constants import MediaType
 
 from PyQt6.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt6.QtWidgets import (
-    QCheckBox, QFormLayout, QGroupBox, QHBoxLayout, QLineEdit, QListWidget,
-    QListWidgetItem, QPushButton, QVBoxLayout, QWidget
+    QCheckBox, QDoubleSpinBox, QFormLayout, QGroupBox, QHBoxLayout, QLineEdit,
+    QListWidget, QListWidgetItem, QPushButton, QVBoxLayout, QWidget
 )
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ class GuiToolsPanel(QWidget):
 
     D_SUBS_PATH = Qt.ItemDataRole.UserRole
 
-    requestSrtSave = pyqtSignal(Path)
+    requestSrtSave = pyqtSignal(Path, float)
     requestSubsLoad = pyqtSignal(Path)
 
     def __init__(self, parent: QWidget) -> None:
@@ -91,6 +91,14 @@ class GuiToolsPanel(QWidget):
 
         self.srtFileName = QLineEdit(self)
         self.srtForm.addRow(self.tr("File Name"), self.srtFileName)
+
+        self.srtOffset = QDoubleSpinBox(self)
+        self.srtOffset.setDecimals(3)
+        self.srtOffset.setSingleStep(0.1)
+        self.srtOffset.setValue(0.0)
+        self.srtOffset.setMinimum(-499999.0)
+        self.srtOffset.setMaximum(499999.0)
+        self.srtForm.addRow(self.tr("Time Offset"), self.srtOffset)
 
         self.srtSubsDir = QCheckBox(self.tr("Use 'Subs' folder"), self)
         self.srtSubsDir.clicked.connect(self._updateTrackInfo)
@@ -176,7 +184,7 @@ class GuiToolsPanel(QWidget):
             folder = Path(self.srtSaveDir.text())
             folder.mkdir(exist_ok=True)
             if name := self.srtFileName.text().strip():
-                self.requestSrtSave.emit(folder / name)
+                self.requestSrtSave.emit(folder / name, self.srtOffset.value())
         except Exception as exc:
             logger.error("Failed to prepare subtitles folder", exc_info=exc)
         return


### PR DESCRIPTION
A small feature that allows adding an offset when writing SRT files. This can be used to correct sync issues, or in context with trimming a video file.