### PR TITLE
Fix dropped PGS acquisition frames

### DIFF
--- a/subtle_gui/formats/pgssubs.py
+++ b/subtle_gui/formats/pgssubs.py
@@ -122,8 +122,10 @@ class PGSSubs(SubtitlesBase):
         frames = []
         for ds in data:
             state = ds.pcs.compState
-            if state == COMP_EPOCH:
+            if state == COMP_EPOCH or (state == COMP_ACQ and not frame):
                 # Start of a new subtitles frame.
+                # We assume that acquisition frames after closed frames are also valid subtitles.
+                # These sometimes occur, and I'm not really sure why.
                 frame = PGSFrame(len(frames), ds)
                 frames.append(frame)
             elif ds.isClearFrame() and frame:

--- a/subtle_gui/ocr/tesseract.py
+++ b/subtle_gui/ocr/tesseract.py
@@ -51,7 +51,7 @@ TXT_REPLACE = {
 
 RX_REPLACE = {
     "all": [
-        (re.compile(r"^(-\s)[\w]", re.UNICODE), "-"),
+        # (re.compile(r"^(-\s)[\w]", re.UNICODE), "-"),
         (re.compile(r"^(\.{2})[\s\w]", re.UNICODE), "..."),
         (re.compile(r"^(\.{3}\s)\w", re.UNICODE), "..."),
         # Wrong capitalisation in the middle of words


### PR DESCRIPTION
Looks like some Blurays use Acquisition frames as new subtitle frames, not just on markers. This changes the logic so that acquisition frames are accepted if there are no other active frames.